### PR TITLE
Fix security bugs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "extra": {
         "display-name": "Discord Notifications",
         "soft-require": {
-            "phpbb/phpbb": ">=3.1.4,<3.2.0@dev"
+            "phpbb/phpbb": ">=3.1.4"
         }
     },
     "require-dev": {

--- a/notification_service.php
+++ b/notification_service.php
@@ -196,8 +196,6 @@ class notification_service
 			return null;
 		}
 
-		$user_id = intval($user_id);
-
 		$sql = "SELECT username from " . USERS_TABLE . " WHERE user_id = " . (int)$user_id;
 		$result = $this->db->sql_query($sql);
 		$data = $this->db->sql_fetchrow($result);

--- a/notification_service.php
+++ b/notification_service.php
@@ -315,20 +315,22 @@ class notification_service
 		}
 
 		// Place the message inside the JSON structure that Discord expects to receive at the REST endpoint.
-		$post = '';
+		$json = array("embeds"=>array(
+			"color"=>$color,
+			"description"=>$message
+			)
+		);
+
 		if (isset($footer))
 		{
-			$post = sprintf('{"embeds": [{"color": "%d", "description" : "%s", "footer": {"text": "%s"}}]}', $color, $message, $footer);
-		}
-		else {
-			$post = sprintf('{"embeds": [{"color": "%d", "description" : "%s"}]}', $color, $message);
+			$json["embeds"]["footer"] = array("text"=>$footer);
 		}
 
 		// Use the CURL library to transmit the message via a POST operation to the webhook URL.
 		$h = curl_init();
 		curl_setopt($h, CURLOPT_URL, $discord_webhook_url);
 		curl_setopt($h, CURLOPT_POST, 1);
-		curl_setopt($h, CURLOPT_POSTFIELDS, $post);
+		curl_setopt($h, CURLOPT_POSTFIELDS, json_encode($json));
 		$response = curl_exec($h);
 		curl_close($h);
 

--- a/notification_service.php
+++ b/notification_service.php
@@ -77,7 +77,7 @@ class notification_service
 		}
 
 		// Query the forum table where forum notification settings are stored
-		$sql = "SELECT discord_notifications_enabled FROM " . FORUMS_TABLE . " WHERE forum_id = $forum_id";
+		$sql = "SELECT discord_notifications_enabled FROM " . FORUMS_TABLE . " WHERE forum_id = " . (int)$forum_id;
 		$result = $this->db->sql_query($sql);
 		$data = $this->db->sql_fetchrow($result);
 		$enabled = $data['discord_notifications_enabled'] == 1 ? true : false;
@@ -107,7 +107,7 @@ class notification_service
 			return null;
 		}
 
-		$sql = "SELECT forum_name from " . FORUMS_TABLE . " WHERE forum_id = $forum_id";
+		$sql = "SELECT forum_name from " . FORUMS_TABLE . " WHERE forum_id = " . (int)$forum_id;
 		$result = $this->db->sql_query($sql);
 		$data = $this->db->sql_fetchrow($result);
 		$name = $data['forum_name'];
@@ -127,7 +127,7 @@ class notification_service
 			return null;
 		}
 
-		$sql = "SELECT post_subject from " . POSTS_TABLE . " WHERE post_id = $post_id";
+		$sql = "SELECT post_subject from " . POSTS_TABLE . " WHERE post_id = " (int)$post_id;
 		$result = $this->db->sql_query($sql);
 		$data = $this->db->sql_fetchrow($result);
 		$subject = $data['post_subject'];
@@ -147,7 +147,7 @@ class notification_service
 			return null;
 		}
 
-		$sql = "SELECT topic_title from " . TOPICS_TABLE . " WHERE topic_id = $topic_id";
+		$sql = "SELECT topic_title from " . TOPICS_TABLE . " WHERE topic_id = " (int)$topic_id;
 		$result = $this->db->sql_query($sql);
 		$data = $this->db->sql_fetchrow($result);
 		$title = $data['topic_title'];
@@ -168,6 +168,8 @@ class notification_service
 			return array();
 		}
 
+		$topic_id = intval($topic_id);
+
 		$topic_table = TOPICS_TABLE;
 		$forum_table = FORUMS_TABLE;
 		$sql = "SELECT
@@ -176,7 +178,7 @@ class notification_service
 				FROM
 				$forum_table f, $topic_table t
 				WHERE
-				t.forum_id = f.forum_id and t.topic_id = $topic_id";
+				t.forum_id = f.forum_id and t.topic_id = ". (int)$topic_id;
 		$result = $this->db->sql_query($sql);
 		$data = $this->db->sql_fetchrow($result);
 		$this->db->sql_freeresult($result);
@@ -196,7 +198,9 @@ class notification_service
 			return null;
 		}
 
-		$sql = "SELECT username from " . USERS_TABLE . " WHERE user_id = $user_id";
+		$user_id = intval($user_id);
+
+		$sql = "SELECT username from " . USERS_TABLE . " WHERE user_id = " . (int)$user_id;
 		$result = $this->db->sql_query($sql);
 		$data = $this->db->sql_fetchrow($result);
 		$name = $data['username'];

--- a/notification_service.php
+++ b/notification_service.php
@@ -168,8 +168,6 @@ class notification_service
 			return array();
 		}
 
-		$topic_id = intval($topic_id);
-
 		$topic_table = TOPICS_TABLE;
 		$forum_table = FORUMS_TABLE;
 		$sql = "SELECT


### PR DESCRIPTION
I was interested in using this code, but upon quick review, I noticed that there was insufficient protection against SQL and JSON injection. So I made a quick PR to fix the issues.

Brief summary: is_numeric isn't a defense against SQL injection, as an attacker can encode their injection as a hexadecimal number instead of ascii text - and it will pass is_numeric, but be decoded by the sql server before execution. The solution is just to cast it to an integer, which isn't large enough to hold a dangerous pile of SQL

The JSON injection comes from the fact that you were taking unsanitized data (messages containing things like usernames), and then just concatenating strings to make the curl query. This could have unexpected/dangerous results, so instead of concatenating strings, I build a PHP object and let php safely convert that to json, with all the proper escaping.