### PR TITLE
Fix for "Cannot send an empty message"

### DIFF
--- a/notification_service.php
+++ b/notification_service.php
@@ -322,6 +322,7 @@ class notification_service
 
 		// Use the CURL library to transmit the message via a POST operation to the webhook URL.
 		$h = curl_init();
+		curl_setopt($h, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
 		curl_setopt($h, CURLOPT_URL, $discord_webhook_url);
 		curl_setopt($h, CURLOPT_POST, 1);
 		curl_setopt($h, CURLOPT_POSTFIELDS, $post);


### PR DESCRIPTION
This will fix the extension not begin able to send messages to discord. After discord API update.